### PR TITLE
Remove redundant assignment

### DIFF
--- a/R/densiometer.R
+++ b/R/densiometer.R
@@ -29,7 +29,6 @@ densiometer <- function(data){
   XCDENBK_data <- data.frame(cbind(data$id[a], (data$Result[a])))
   colnames(XCDENBK_data) <- c("id", "Result")
   transform <- function(data) as.numeric(as.character(data))*(100/17)
-  XCDENBK_data$trans <- 1:length(XCDENBK_data$Result)
   XCDENBK_data$trans <- (transform(XCDENBK_data$Result))
   sumna <- function(data)sum(data, na.rm = T)
   XCDENBK_sum <- tapply(XCDENBK_data$trans, XCDENBK_data$id, sumna)


### PR DESCRIPTION
Need to test this diff with some more datasets to be confident that it's correct.


A current error:
```R
> failure_df = readr::read_csv("failed-907CCCR02-2025.csv")
> success_df = readr::read_csv("successful-907CCCR02-2010.csv")
> phabmetrics(failure_df)

Error in `$<-.data.frame`:
! replacement has 2 rows, data has 0
```

Old code:
https://github.com/SCCWRP/PHABMetrics/blob/a96a2db39ed315f25c4bf22b9567ee350def85fd/R/densiometer.R#L32-L33

Change:
Delete line 32.

I think the code change works because if `XCDENBK_data$Result` is empty, then you get a 2-element vector, whereas if it's length 1 or more, you get a vector the length of `XCDENBK_data$Result`

```R
> 1:0
[1] 1 0
> 1:1
[1] 1
```

The sample data `sampdat` seems to transform the same under the `phabmetrics` function.

R:
```R
# pre-change CSV output
> phabmetrics(sampdat) %>% dplyr::arrange() |> readr::write_csv("samp_out_pre.csv")

# post-change CSV output
> phabmetrics(sampdat) %>% dplyr::arrange() |> readr::write_csv("samp_out_post.csv")
```

zsh:
```sh
diff ./samp_out_pre.csv ./samp_out_post.csv
# Empty diff
```