### PR TITLE
Phabmetrics: don't skip on failed metric calculation

### DIFF
--- a/R/phabmetrics.R
+++ b/R/phabmetrics.R
@@ -1,92 +1,121 @@
 #' Calculate all PHAB metrics
 #'
 #' @param data Input data
-#' 
+#'
 #' @export
-#' 
+#'
 #' @importFrom magrittr "%>%"
 #'
-#' @examples 
+#' @examples
 #' \dontrun{
 #' phabmetrics(sampdat)
 #' }
-phabmetrics <- function(data){
-  if (!("sampleagencycode" %in% tolower(names(data)))){
-    data <- data %>% 
+phabmetrics <- function(data) {
+  if (!("sampleagencycode" %in% tolower(names(data)))) {
+    data <- data %>%
       dplyr::mutate(
         SampleAgencyCode = 'Not Recorded'
       )
   }
-  
+
   # format input
   data <- phabformat(data)
-  
+
   # chkinp threw off values of sinuosity metrics by removing rows of data
   # We should probably let the checker application check the data so users (and us) are aware of any problems with their data
   data <- chkinp(data, purge = TRUE)
-  
+
   # calc metrics
-  metrics <- list(bankmorph(data), channelmorph(data), channelsinuosity(data),
-                  densiometer(data),  habitat(data), disturbance(data), flow(data),
-                  misc(data), bankstability(data), quality(data), ripveg(data),
-                  substrate(data), algae(data))
+  metrics <- list(
+    bankmorph(data),
+    channelmorph(data),
+    channelsinuosity(data),
+    densiometer(data),
+    habitat(data),
+    disturbance(data),
+    flow(data),
+    misc(data),
+    bankstability(data),
+    quality(data),
+    ripveg(data),
+    substrate(data),
+    algae(data)
+  )
 
-  # combine seprate metrics lists 
-  out <- purrr::map(metrics, function(x){
-
-    lnfrm <- x %>% 
-      as.data.frame(stringsAsFactors = FALSE) %>% 
-      tibble::rownames_to_column('phab_sampleid') %>% 
-      dplyr::mutate_if(is.numeric, as.character) %>% 
+  # combine seprate metrics lists
+  out <- purrr::map(metrics, function(x) {
+    lnfrm <- x %>%
+      as.data.frame(stringsAsFactors = FALSE) %>%
+      tibble::rownames_to_column('phab_sampleid') %>%
+      dplyr::mutate_if(is.numeric, as.character) %>%
       tidyr::gather('var', 'val', -phab_sampleid)
-    
+
     return(lnfrm)
-    
-  }) %>% 
-  do.call('rbind', .) %>% 
-  dplyr::mutate(
-    val = gsub('NaN', NA, val)
-  ) %>% 
-  tidyr::spread('var', 'val') %>% 
-  dplyr::mutate_if(
-    ~ !any(grepl('[a-z,A-Z]', .x)), as.numeric
+  }) %>%
+    do.call('rbind', .) %>%
+    dplyr::mutate(
+      val = gsub('NaN', NA, val)
+    ) %>%
+    tidyr::spread('var', 'val') %>%
+    dplyr::mutate_if(
+      ~ !any(grepl('[a-z,A-Z]', .x)),
+      as.numeric
     )
-  
-  
-  out <- out %>% 
+
+  out <- out %>%
     dplyr::left_join(
-      data %>% 
+      data %>%
         dplyr::mutate(
           phab_sampleid = dplyr::case_when(
             toupper(SampleAgencyCode) != 'NOT RECORDED' ~ paste(
-              StationCode, SampleDate, SampleAgencyCode, sep = "_"
+              StationCode,
+              SampleDate,
+              SampleAgencyCode,
+              sep = "_"
             ),
-            toupper(SampleAgencyCode) == 'NOT RECORDED' ~ paste(StationCode, SampleDate, sep = "_"),
+            toupper(SampleAgencyCode) == 'NOT RECORDED' ~ paste(
+              StationCode,
+              SampleDate,
+              sep = "_"
+            ),
             TRUE ~ NA_character_
           )
         ) %>%
         dplyr::select(
-          phab_sampleid, StationCode, SampleDate, SampleAgencyCode
+          phab_sampleid,
+          StationCode,
+          SampleDate,
+          SampleAgencyCode
         ) %>%
-        dplyr::distinct(phab_sampleid,StationCode,SampleDate,SampleAgencyCode)
-      , by = 'phab_sampleid'
+        dplyr::distinct(
+          phab_sampleid,
+          StationCode,
+          SampleDate,
+          SampleAgencyCode
+        ),
+      by = 'phab_sampleid'
     )
-  
+
   out <- out %>%
     dplyr::select(
-      c(phab_sampleid,StationCode,SampleDate,SampleAgencyCode,
-      names(out)[which(!(names(out) %in% c('StationCode','SampleDate','SampleAgencyCode','phab_sampleid')))]
+      c(
+        phab_sampleid,
+        StationCode,
+        SampleDate,
+        SampleAgencyCode,
+        names(out)[which(
+          !(names(out) %in%
+            c('StationCode', 'SampleDate', 'SampleAgencyCode', 'phab_sampleid'))
+        )]
       )
     )
-  
+
   out <- longformat(out) %>% select(-phab_sampleid)
-  
+
   if ((out %>% dplyr::distinct(SampleAgencyCode) == 'Not Recorded') %>% all()) {
     out <- out %>%
       dplyr::select(-SampleAgencyCode)
   }
-  
-  
+
   return(out)
-  
 }

--- a/R/phabmetrics.R
+++ b/R/phabmetrics.R
@@ -32,8 +32,6 @@ phabmetrics <- function(data, output_errors = FALSE) {
   # We should probably let the checker application check the data so users (and us) are aware of any problems with their data
   data <- chkinp(data, purge = TRUE)
 
-  bankmorph_metrics = bankmorph(data)
-
   metrics_functions = list(
     bankmorph = bankmorph,
     channelmorph = channelmorph,

--- a/R/phabmetrics.R
+++ b/R/phabmetrics.R
@@ -62,6 +62,10 @@ phabmetrics <- function(data, output_errors = FALSE, one_fails_all = TRUE) {
       }
     )
 
+    if (!output_errors && one_fails_all && nrow(err_log) > 0) {
+      stop(err_log$msg)
+    }
+
     if (!is.null(res)) {
       metrics[[f_name]] <- res
     }
@@ -150,12 +154,12 @@ phabmetrics <- function(data, output_errors = FALSE, one_fails_all = TRUE) {
       out = out,
       errors = err_log
     ))
-  } else if (output_errors && one_fails_all && length(err_log) > 0) {
+  } else if (output_errors && one_fails_all && nrow(err_log) > 0) {
     return(list(
       out = NULL,
       errors = err_log
     ))
-  } else if (!output_errors && one_fails_all && length(err_log) > 0) {
+  } else if (!output_errors && one_fails_all && nrow(err_log) > 0) {
     return(NULL)
   } else {
     return(out)

--- a/R/phabmetrics.R
+++ b/R/phabmetrics.R
@@ -2,6 +2,7 @@
 #'
 #' @param data Input data for phab metrics
 #' @param output_errors Output a named list; "out" is the original output, "errors" is individual errors for each subfunction
+#' @param one_fails_all On TRUE, don't output analysis if any subfunctions fail
 #'
 #' @export
 #'
@@ -11,6 +12,7 @@
 #' \dontrun{
 #' phabmetrics(sampdat)
 #' }
+phabmetrics <- function(data, output_errors = FALSE, one_fails_all = TRUE) {
   metrics = list()
   err_log = data.frame(
     func = character(),

--- a/R/phabmetrics.R
+++ b/R/phabmetrics.R
@@ -144,12 +144,19 @@ phabmetrics <- function(data, output_errors = FALSE, one_fails_all = TRUE) {
       dplyr::select(-SampleAgencyCode)
   }
 
-  if (output_errors) {
+  if (output_errors && !one_fails_all) {
     # Return the named list structure
     return(list(
       out = out,
       errors = err_log
     ))
+  } else if (output_errors && one_fails_all && length(err_log) > 0) {
+    return(list(
+      out = NULL,
+      errors = err_log
+    ))
+  } else if (!output_errors && one_fails_all && length(err_log) > 0) {
+    return(NULL)
   } else {
     return(out)
   }

--- a/R/phabmetrics.R
+++ b/R/phabmetrics.R
@@ -1,6 +1,7 @@
 #' Calculate all PHAB metrics
 #'
-#' @param data Input data
+#' @param data Input data for phab metrics
+#' @param output_errors Output a named list; "out" is the original output, "errors" is individual errors for each subfunction
 #'
 #' @export
 #'
@@ -10,7 +11,6 @@
 #' \dontrun{
 #' phabmetrics(sampdat)
 #' }
-phabmetrics <- function(data, output_errors = FALSE) {
   metrics = list()
   err_log = data.frame(
     func = character(),


### PR DESCRIPTION
Currently, if a metric function fails to be calculated, the whole `phabmetrics` function fails, and we don't get any metrics for the given sample.

If there are errors:

`output_errors` | `one_fails_all` | behavior
--- | --- | ---
`FALSE` | `TRUE` | no individual error messages, one failure causes entire failure (current default behavior)
`FALSE` | `FALSE` | no individual error output, output available metrics
`TRUE` | `TRUE` | output individual errors, output null for `$out`
`TRUE` | `FALSE` | output individual errors, output calculable subset of metrics